### PR TITLE
fix: correct types import path

### DIFF
--- a/services/db.ts
+++ b/services/db.ts
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import type { Trade } from './types';
+import type { Trade } from '../types';
 // Fix: Correctly import Dexie and the `Table` type to resolve typing issues with subclassing.
 import Dexie, { type Table } from 'dexie';
 


### PR DESCRIPTION
## Summary
- fix TypeScript import path in db service

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b466976be48326bd5d91ba15348c50